### PR TITLE
Add Nix flake.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ polyglot_watcher_v2-*.tar
 polyglot_watcher_v2
 polyglot_watcher_v2_dev
 polyglot_watcher_v2_test
+
+# Nix.
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1697730408,
+        "narHash": "sha256-Ww//zzukdTrwTrCUkaJA/NsaLEfUfQpWZXBdXBYfhak=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ff0a5a776b56e0ca32d47a4a47695452ec7f7d80",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,58 @@
+{
+  description = "A software development tool to trigger test runs on file save ";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pname = "polyglot_watcher_v2";
+      version = "0.1.0";
+
+      pkgs = import nixpkgs {inherit system;};
+      beamPackages = pkgs.beam.packages.erlang_25;
+      elixir = beamPackages.elixir_1_14;
+      hex = beamPackages.hex;
+    in {
+      # `nix develop`.
+      devShells = {
+        default = pkgs.mkShell {
+          packages = [
+            elixir
+            pkgs.fswatch
+          ];
+        };
+      };
+      # `nix fmt`.
+      formatter = pkgs.alejandra;
+      # `nix build`.
+      packages = {
+        polyglot-watcher-v2 = pkgs.stdenvNoCC.mkDerivation {
+          inherit pname version;
+          src = pkgs.nix-gitignore.gitignoreSource [] ./.;
+          nativeBuildInputs = [elixir pkgs.makeWrapper];
+          buildPhase = ''
+            # Expose Nix's hex to Mix.
+            export MIX_PATH="${hex}/lib/erlang/lib/hex/ebin"
+            export HOME=$PWD/.hex
+            mkdir -p $HOME
+            mix deps.get
+            env MIX_ENV=prod mix escript.build
+          '';
+          installPhase = ''
+            mkdir -p $out/bin
+            cp ${pname} $out/bin/${pname}
+            wrapProgram $out/bin/${pname} \
+              --prefix PATH : ${pkgs.lib.makeBinPath [beamPackages.erlang pkgs.fswatch]}
+          '';
+        };
+        default = self.packages.${system}.polyglot-watcher-v2;
+      };
+    });
+}


### PR DESCRIPTION
Not intending this to be merged, but just a record of the work I did bundling this up as a Nix flake so that Multiverse projects which are already flake-ified can easily consume polyglot_watcher_v2.

Nothing particularly unusual here, other than having to work around [the `priv/` directory not being accessible by escripts](https://elixirforum.com/t/code-priv-dir-doesnt-work-in-escript/4462/2). For that I embedded the zombie killer script into the server module and then write it to a temporary executable. Pretty gross!